### PR TITLE
Respect foldopen setting

### DIFF
--- a/plugin/timed-highlight.lua
+++ b/plugin/timed-highlight.lua
@@ -1,8 +1,17 @@
 -- ensure n and N highlight for only a brief time
-local lua_command_string = ":lua require('timed-highlight').turn_off_highlight_after_expiration()<CR>"
 
-vim.api.nvim_set_keymap('n', 'n', 'n' .. lua_command_string, { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', 'N', 'N' .. lua_command_string, { noremap = true, silent = true })
+local function searchAndOpenFold(key)
+    vim.cmd('normal! ' .. key)
+
+    if string.find(vim.o.foldopen, "search") and vim.fn.foldclosed('.') ~= -1 then
+        vim.cmd('normal! zv')
+    end
+
+    require('timed-highlight').turn_off_highlight_after_expiration()
+end
+
+vim.keymap.set('n', 'n', function() searchAndOpenFold('n') end, {noremap = true, silent = true})
+vim.keymap.set('n', 'N', function() searchAndOpenFold('N') end, {noremap = true, silent = true})
 
 -- ensure the initial lookup using / or ? highlight for only a brief time
 vim.api.nvim_create_autocmd("CmdlineLeave", {


### PR DESCRIPTION
If the user does `set foldopen=search`, then a fold should be opened if it contains a search result. However, according to the neovim source code, if the 'n' key comes from a mapping, this fold opening behavior is not triggered:

https://github.com/neovim/neovim/blob/01e4a70d668d54a7cefa3ff53ec97e39df516265/src/nvim/search.c#L2511C1-L2514C1

There is the `t` flag in `feedkeys()` that makes the character sequence appear as if typed by the user (this satisfying the conditions in the source code lines above), but to remap `n` to emit `n` in this case would lead to a recursive mapping (the `n` flag of `feedkeys()` would be needed to avoid that). 

Instead, this PR does manually what the `search` setting in `foldopen` would do.